### PR TITLE
Find and fix three bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "eslint": "^9.9.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
+        "fake-indexeddb": "^6.1.0",
         "globals": "^15.9.0",
         "jsdom": "^26.1.0",
         "lovable-tagger": "^1.1.7",
@@ -7059,6 +7060,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.1.0.tgz",
+      "integrity": "sha512-gOzajWIhEug/CQHUIxigKT9Zilh5/I6WvUBez6/UdUtT/YVEHM9r572Os8wfvhp7TkmgBtRNdqSM7YoCXWMzZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
+    "fake-indexeddb": "^6.1.0",
     "globals": "^15.9.0",
     "jsdom": "^26.1.0",
     "lovable-tagger": "^1.1.7",

--- a/src/lib/testing/biasTester.test.ts
+++ b/src/lib/testing/biasTester.test.ts
@@ -1,7 +1,29 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 type Label = 0 | 1;
 type Group = 'A' | 'B';
+
+// Simple deterministic PRNG (Mulberry32)
+function createSeededRandom(seed: number) {
+  let t = seed >>> 0;
+  return function random() {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const ORIGINAL_RANDOM = Math.random;
+
+beforeEach(() => {
+  // Use a fixed seed so test is stable
+  Math.random = createSeededRandom(123456789);
+});
+
+afterEach(() => {
+  Math.random = ORIGINAL_RANDOM;
+});
 
 function simulatePredictions(nPerGroup = 200, biasDelta = 0.02) {
   // Create two groups with slightly different positive rates

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -16,6 +16,7 @@
  */
 
 import { beforeAll, afterEach } from 'vitest';
+import './i18n';
 
 // Runs once before any test suites execute
 beforeAll(() => {

--- a/tests/setup.polyfills.ts
+++ b/tests/setup.polyfills.ts
@@ -2,6 +2,8 @@
  * Global storage and window polyfills for Node test environment.
  * Loaded by Vitest via setupFiles in vitest.config.ts before any test imports.
  */
+import 'fake-indexeddb/auto';
+
 const defineStorage = (targetKey: 'localStorage' | 'sessionStorage') => {
   if (!(globalThis as any)[targetKey]) {
     const store = new Map<string, string>();


### PR DESCRIPTION
Fixes three bugs related to testing environment setup and test stability.

This PR addresses:
- An `IndexedDB ReferenceError` in tests by adding a `fake-indexeddb` polyfill.
- An i18n instance warning in component tests by initializing i18n during test setup.
- A flaky bias test by seeding `Math.random` for deterministic results.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b5e7e59-96e5-4ae2-82c0-4ec2458d7a70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b5e7e59-96e5-4ae2-82c0-4ec2458d7a70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

